### PR TITLE
docs: remove example of "update" api from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ $processes = new Processes;
 // Get all active processes
 print_r($processes->get());
 
-// OR
-
-// Update all active processes
-print_r($processes->update());
-
 /* 
     OUTPUT FORMAT: 
 


### PR DESCRIPTION
It can be a little confusing that we have the ability
to update current work processes in the system.

Actually, that means what we have the ability to update
processes on an instance of Processes class not within the entire system.